### PR TITLE
Document `--version` option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ Bundler plugin for showing diffs of bundled gems against latest versions.
     $ bundle diff GEMNAME
 
 Tip: use `bundle outdated` to list installed gems with with newer versions available.
+
+You can also specify the version of the gem to diff against:
+
+    $ bundle diff GEMNAME --version 1.2.3
+    


### PR DESCRIPTION
Thanks for writing this Gem! It's very helpful when Depfu can't show a Changelog.

I noticed that you added the `--version` option a few years ago, but hadn't updated the README. 